### PR TITLE
Clone and add semantics

### DIFF
--- a/ctor.go
+++ b/ctor.go
@@ -61,12 +61,6 @@ func newCtor(t reflect.Type, v reflect.Value) *ctor {
 	}
 }
 
-func (c ctor) clone() *ctor {
-	c.once = &sync.Once{}
-	c.errChan = make(chan error)
-	return &c
-}
-
 func (c *ctor) testParametersAreRegisteredIn(s *Psyringe) error {
 	for paramIndex, paramType := range c.inTypes {
 		if err := s.testValueOrConstructorIsRegistered(paramType); err != nil {

--- a/psyringe.go
+++ b/psyringe.go
@@ -136,7 +136,7 @@ func (p *Psyringe) Clone() *Psyringe {
 	q.values = map[reflect.Type]reflect.Value{}
 	q.injectionTypes = map[reflect.Type]struct{}{}
 	for t, c := range p.ctors {
-		q.ctors[t] = c.clone()
+		q.ctors[t] = c
 	}
 	for t, v := range p.values {
 		q.values[t] = v

--- a/psyringe_clone_test.go
+++ b/psyringe_clone_test.go
@@ -9,6 +9,14 @@ type (
 	TestCloneNeedsInt struct {
 		Int int64
 	}
+
+	beforeClone string
+	afterClone  string
+
+	TestCloneSequence struct {
+		Before beforeClone
+		After  afterClone
+	}
 )
 
 func TestPsyringe_Clone(t *testing.T) {
@@ -41,41 +49,107 @@ func TestPsyringe_Clone(t *testing.T) {
 	clone1.Add(func() func() { return nil })
 	clone2.Add(func() func() { return nil })
 
-	ns := TestCloneNeedsString{}
+}
 
-	// Inject 999 times using the original psyringe, the string should still be
-	// #1 since the string constructor is called only once for that psyringe.
-	for i := 0; i < 999; i++ {
+func TestPsyringe_Clone_Sequencing(t *testing.T) {
+	var stringCounter Counter
+
+	original := New()
+
+	original.Add(func() beforeClone {
+		stringCounter.Increment()
+		return beforeClone("before" + stringCounter.String())
+	})
+
+	clone := original.Clone()
+
+	var testTarget TestCloneSequence
+
+	// injections registered before cloning should be identical
+	original.MustInject(&testTarget)
+	if string(testTarget.Before) != "before1" {
+		t.Errorf("Expected original injection to be before1, was %s", testTarget.Before)
+	}
+	clone.MustInject(&testTarget)
+	if string(testTarget.Before) != "before1" {
+		t.Errorf("Expected clone injection to be before1, was %s", testTarget.Before)
+	}
+
+	// injections registered before cloning should be stable
+	original.MustInject(&testTarget)
+	if string(testTarget.Before) != "before1" {
+		t.Errorf("Expected original injection to be before1, was %s", testTarget.Before)
+	}
+	clone.MustInject(&testTarget)
+	if string(testTarget.Before) != "before1" {
+		t.Errorf("Expected clone injection to be before1, was %s", testTarget.Before)
+	}
+
+	after := func() afterClone {
+		stringCounter.Increment()
+		return afterClone("after" + stringCounter.String())
+	}
+
+	original.Add(after)
+	clone.Add(after)
+
+	// injections registered after cloning should be distinct
+	original.MustInject(&testTarget)
+	if string(testTarget.After) != "after2" {
+		t.Errorf("Expected original injection to be after2, was %s", testTarget.After)
+	}
+	clone.MustInject(&testTarget)
+	if string(testTarget.After) != "after3" {
+		t.Errorf("Expected clone injection to be after3, was %s", testTarget.After)
+	}
+
+	// should be stable, though
+	original.MustInject(&testTarget)
+	if string(testTarget.After) != "after2" {
+		t.Errorf("Expected original injection to be after2, was %s", testTarget.After)
+	}
+	clone.MustInject(&testTarget)
+	if string(testTarget.After) != "after3" {
+		t.Errorf("Expected clone injection to be after3, was %s", testTarget.After)
+	}
+
+	/*
+		ns := TestCloneNeedsString{}
+
+		// Inject 999 times using the original psyringe, the string should still be
+		// #1 since the string constructor is called only once for that psyringe.
+		for i := 0; i < 999; i++ {
+			original.MustInject(&ns)
+		}
 		original.MustInject(&ns)
-	}
-	original.MustInject(&ns)
-	expected := "#1"
-	if ns.String != expected {
-		t.Fatalf("got %q; want %q", ns.String, expected)
-	}
+		expected := "#1"
+		if ns.String != expected {
+			t.Fatalf("got %q; want %q", ns.String, expected)
+		}
 
-	// Now inject using the clone 999 times, this time the string should be
-	// #2 because we called the clone's constructor, but only once.
-	for i := 0; i < 999; i++ {
-		clone1.MustInject(&ns)
-	}
-	expected = "#2"
-	if ns.String != expected {
-		t.Fatalf("got %q; want %q", ns.String, expected)
-	}
+		// Now inject using the clone 999 times, this time the string should be
+		// #2 because we called the clone's constructor, but only once.
+		for i := 0; i < 999; i++ {
+			clone1.MustInject(&ns)
+		}
+		expected = "#2"
+		if ns.String != expected {
+			t.Fatalf("got %q; want %q", ns.String, expected)
+		}
 
-	// For fun, let's inject with the original Psyringe again...
-	original.MustInject(&ns)
-	expected = "#1"
-	if ns.String != expected {
-		t.Fatalf("got %q; want %q", ns.String, expected)
-	}
+		// For fun, let's inject with the original Psyringe again...
+		original.MustInject(&ns)
+		expected = "#1"
+		if ns.String != expected {
+			t.Fatalf("got %q; want %q", ns.String, expected)
+		}
 
-	// Inject with the second clone.
-	clone2.MustInject(&ns)
-	expected = "#3"
-	if ns.String != expected {
-		t.Fatalf("got %q; want %q", ns.String, expected)
-	}
+		// Inject with the second clone.
+		clone2.MustInject(&ns)
+		expected = "#3"
+		if ns.String != expected {
+			t.Fatalf("got %q; want %q", ns.String, expected)
+		}
+	*/
 
 }


### PR DESCRIPTION
Prior: Clone() "reset" all ctor value calculations, by cloning the ctors
themselves. The result is that it was impossible for a "root" Psyringe and a
"child" to inject identical values, iff that value was the result of a ctor, as
opposed to a registered value. In some cases this was convenient, but it led to
the case where it would be necessary to maintain a list of DIs in order to
provide an identical value.

Post: Clone() retains all the ctors from the original, and values are
consistent between the two. ctors Add()ed after Clone() are, obviously, not
available to the other Psyringe. Differing ctors can thereby be had by Clone()
then Add().

This is more in line with the behavior of values, as well.